### PR TITLE
Accommodate spaces when executing commands

### DIFF
--- a/src/main/kotlin/works/szabope/plugins/mypy/MypyArgs.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/MypyArgs.kt
@@ -2,5 +2,5 @@ package works.szabope.plugins.mypy
 
 object MypyArgs {
     const val MYPY_RECOMMENDED_COMMAND_ARGS = "--follow-imports silent --exclude \\.pyi\$"
-    const val MYPY_MANDATORY_COMMAND_ARGS = "--show-column-numbers --show-absolute-path --output json"
+    val MYPY_MANDATORY_COMMAND_ARGS: List<String> = listOf("--show-column-numbers", "--show-absolute-path", "--output", "json")
 }

--- a/src/main/kotlin/works/szabope/plugins/mypy/configurable/MypySettingConfigurable.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/configurable/MypySettingConfigurable.kt
@@ -86,7 +86,7 @@ internal class MypySettingConfigurable(private val project: Project) : BoundSear
                     }).align(AlignX.RIGHT + AlignY.CENTER)
                 }.rowComment(
                     MyBundle.message(
-                        "mypy.settings.path_to_executable.comment", MypyArgs.MYPY_MANDATORY_COMMAND_ARGS
+                        "mypy.settings.path_to_executable.comment", MypyArgs.MYPY_MANDATORY_COMMAND_ARGS.joinToString(" ")
                     ), maxLineLength = MAX_LINE_LENGTH_WORD_WRAP
                 ).layout(RowLayout.PARENT_GRID)
                 row {

--- a/src/main/kotlin/works/szabope/plugins/mypy/services/MypySettings.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/services/MypySettings.kt
@@ -159,7 +159,7 @@ class MypySettings(internal val project: Project) :
 
             val stdout = StringBuilder()
             val processResult = runBlocking {
-                Cli().execute("$path -V") { it.collect(stdout::appendLine) }
+                Cli().execute(listOf("$path", "-V")) { it.collect(stdout::appendLine) }
             }
             if (processResult.resultCode != 0) {
                 return SettingsValidationProblem(
@@ -217,7 +217,7 @@ class MypySettings(internal val project: Project) :
     }
 
     suspend fun autodetectExecutable(): String? {
-        val locateCommand = if (SystemInfo.isWindows) "where.exe mypy.exe" else "which mypy"
+        val locateCommand = if (SystemInfo.isWindows) listOf("where.exe", "mypy.exe") else listOf("which", "mypy")
         val stdout = StringBuilder()
         val processResult = PythonEnvironmentAwareCli(project).execute(locateCommand) { it.collect(stdout::appendLine) }
         return when (processResult.resultCode) { // same for linux and windows
@@ -229,7 +229,7 @@ class MypySettings(internal val project: Project) :
                 ) {
                     if (it.eventType == HyperlinkEvent.EventType.ACTIVATED) {
                         IDialogManager.showMypyExecutionErrorDialog(
-                            locateCommand,
+                            locateCommand.joinToString(" "),
                             processResult.stderr,
                             processResult.resultCode
                         )

--- a/src/main/kotlin/works/szabope/plugins/mypy/services/cli/Cli.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/services/cli/Cli.kt
@@ -13,16 +13,16 @@ class Cli {
     }
 
     suspend fun execute(
-        command: String,
+        command: List<String>,
         workDir: String? = null,
         env: Map<String, String>? = null,
         stdout: suspend (Flow<String>) -> Unit
     ): Status {
-        require(command.isNotBlank())
+        require(command.isNotEmpty())
         val directory = workDir?.let { java.io.File(workDir) }
         return withContext(Dispatchers.IO) {
             val result = process(
-                *command.split(" ").toTypedArray(),
+                *command.toTypedArray(),
                 stdout = Redirect.Consume { stdout(it) },
                 stderr = Redirect.CAPTURE,
                 directory = directory,

--- a/src/main/kotlin/works/szabope/plugins/mypy/services/cli/PythonEnvironmentAwareCli.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/services/cli/PythonEnvironmentAwareCli.kt
@@ -7,12 +7,12 @@ import kotlinx.coroutines.flow.Flow
 
 class PythonEnvironmentAwareCli(private val project: Project) {
 
-    suspend fun execute(command: String, workDir: String? = null, handle: suspend (Flow<String>) -> Unit): Cli.Status {
-        require(command.isNotBlank())
+    suspend fun execute(command: List<String>, workDir: String? = null, handle: suspend (Flow<String>) -> Unit): Cli.Status {
+        require(command.isNotEmpty())
         val environment = getEnvironment().toMutableMap()
         val environmentAwareCommand = PyVirtualEnvTerminalCustomizer().customizeCommandAndEnvironment(
-            project, project.basePath, command.split(" ").toTypedArray(), environment
-        ).filter { it.isNotEmpty() }.joinToString(" ")
+            project, project.basePath, command.toTypedArray(), environment
+        ).toList()
         return Cli().execute(environmentAwareCommand, workDir, environment) { handle(it) }
     }
 


### PR DESCRIPTION
Background: my home directory includes a space in its name, unfortunately, and I found that the plugin couldn't run `mypy.exe` when it needed it. (It just reported error code 1 or similar.)

This pull request changes the code in various places to use `List<String>`, instead of space-delimited `String`, when representing an executable command or its arguments. This helps to avoid the need for space as a delimiter for `mypy.exe` and filename arguments. 

Note: I originally changed more code to use `List<String>`, but it got out of hand when it came to UI code (at least for me as a newcomer to this code). Also, I think having the user enter a list of strings separately would be overkill in most cases. So I've kept the type of `MypyState.arguments`, `MypySettings.arguments` and `MypyArgs.MYPY_RECOMMENDED_COMMAND_ARGS` as plain (space-delimited) `String`. (So if the user specifies a custom argument, which includes a filename, which includes a space, **that** will still fail. But I like to think these changes are an improvement in any case.)