### PR TITLE
Invoke mypy as module, not as executable

### DIFF
--- a/src/main/kotlin/works/szabope/plugins/mypy/actions/InstallMypyAction.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/actions/InstallMypyAction.kt
@@ -33,7 +33,7 @@ class InstallMypyAction : DumbAwareAction() {
                     )
                     with(OldMypySettings.getInstance(project)) {
                         MypySettings.getInstance(project)
-                            .initSettings(customMypyPath, mypyConfigFilePath, mypyArguments)
+                            .initSettings(mypyConfigFilePath, mypyArguments)
                     }
                 } else {
                     val title = MyBundle.message("action.InstallMypyAction.fail_html")

--- a/src/main/kotlin/works/szabope/plugins/mypy/activity/MypySettingsInitializationActivity.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/activity/MypySettingsInitializationActivity.kt
@@ -32,7 +32,7 @@ internal class MypySettingsInitializationActivity : ProjectActivity {
         val settings = MypySettings.getInstance(project)
         if (!settings.isComplete()) {
             with(OldMypySettings.getInstance(project)) {
-                settings.initSettings(customMypyPath, mypyConfigFilePath, mypyArguments)
+                settings.initSettings(mypyConfigFilePath, mypyArguments)
             }
         }
         if (!settings.isComplete()) {

--- a/src/main/kotlin/works/szabope/plugins/mypy/mypySettingsMapper.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/mypySettingsMapper.kt
@@ -4,5 +4,5 @@ import works.szabope.plugins.mypy.services.MypyService
 import works.szabope.plugins.mypy.services.MypySettings
 
 fun MypySettings.toRunConfiguration() = MypyService.RunConfiguration(
-    mypyExecutable!!, configFilePath, arguments, isExcludeNonProjectFiles, customExclusions, projectDirectory!!
+    configFilePath, arguments, isExcludeNonProjectFiles, customExclusions, projectDirectory!!
 )

--- a/src/main/kotlin/works/szabope/plugins/mypy/services/MypyPackageUtil.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/services/MypyPackageUtil.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture
 
 object MypyPackageUtil {
 
-    private val PACKAGE = RepoPackage("mypy", null)
+    internal val PACKAGE = RepoPackage("mypy", null)
 
     fun canInstall(project: Project): Boolean {
         val sdk = project.pythonSdk ?: return false

--- a/src/main/kotlin/works/szabope/plugins/mypy/services/OldMypySettings.kt
+++ b/src/main/kotlin/works/szabope/plugins/mypy/services/OldMypySettings.kt
@@ -17,13 +17,10 @@ class OldMypySettings : SimplePersistentStateComponent<OldMypySettings.OldMypySe
 
     @ApiStatus.Internal
     class OldMypySettingsState : BaseState() {
-        var customMypyPath by string()
         var mypyConfigFilePath by string()
         var mypyArguments by string()
     }
 
-    val customMypyPath
-        get() = state.customMypyPath
     val mypyConfigFilePath
         get() = state.mypyConfigFilePath
     val mypyArguments

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -1,7 +1,5 @@
 mypy.configurable.name=Mypy
 mypy.settings.incomplete=Mypy configuration is incomplete
-mypy.settings.path_to_executable.empty_warning=Mypy is not specified
-mypy.settings.path_to_executable.label=Path to mypy executable:
 mypy.settings.path_to_executable.comment=Mandatory (and implicitly set) arguments: {0}
 mypy.settings.path_to_executable.exited_with_error=Running {0} returned status code {1} with error {2}
 mypy.settings.path_to_executable.unknown_version=Unable to identify mypy version (-V)


### PR DESCRIPTION
This PR is just for reference, at least for now. My manual tests so far have failed, because the mypy I need to run is too old to support `--output json`.

It's also possible I have deleted too much of the configuration UI (mandatory parameter info) or of [Old]MypySettings.